### PR TITLE
Use Bootstrap cards instead of table

### DIFF
--- a/app/views/houses/index.html.erb
+++ b/app/views/houses/index.html.erb
@@ -7,23 +7,22 @@
   </div>
 </div>
 
-<div class="table-responsive">
-  <table class="table table-striped">
-    <thead>
-      <tr>
-        <th>Rent</th>
-        <th>Deposit</th>
-        <th>Preferred gender</th>
-      </tr>
-    </thead>
-    <tbody>
-      <% @houses.each do |house| %>
-      <tr>
-        <td><%= link_to "$ #{house.rent}", house_path(house) %></td>
-        <td>$ <%= house.deposit %></td>
-        <td><%= house.preferred_gender %></td>
-      </tr>
-      <% end %>
-    </tbody>
-  </table>
+<div class="card-columns">
+  <% @houses.each do |house| %>
+  <a href="<%= house_path(house) %>" class="text-dark">
+    <div class="card">
+      <div class="card-body">
+        <p class="card-text">
+          <b>Rent</b>: $ <%= house.rent %><br>
+          <b>Deposit</b>: $ <%= house.deposit %>
+        </p>
+        <p class="card-text">
+          <b>Address</b>: <br>
+          <%= house.address.address_1 %> <%= house.address.address_2 %><br>
+          <%= house.address.city %> <%= house.address.state %>, <%= house.address.zip_code %>
+        </p>
+      </div>
+    </div>
+  </a>
+  <% end %>
 </div>


### PR DESCRIPTION
This PR changes the UI of `houses#index` from Bootstrap table classes to Bootstrap cards classes. It uses card-columns for different display.

A card has few basic information. Rent, deposit and address. For other additional information they need to see house specific page.

## Screenshots

Laptop view
![Screenshot from my laptop](https://user-images.githubusercontent.com/24360355/44290076-e390a100-a22b-11e8-9f18-0fa3ac8c53cb.png)

Phone view
![Screenshot from Samsung J7 2016](https://user-images.githubusercontent.com/24360355/44290060-cf4ca400-a22b-11e8-9c08-a5d5e7bcf3b7.png)
